### PR TITLE
Added parsing of uses constraints

### DIFF
--- a/src/main/java/org/neo4j/osgi/importer/AbstractFileBundleImporter.java
+++ b/src/main/java/org/neo4j/osgi/importer/AbstractFileBundleImporter.java
@@ -11,9 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
@@ -56,10 +54,30 @@ public abstract class AbstractFileBundleImporter implements FileBundleImporter {
         List<Package> packages = new ArrayList<Package>();
         packages.addAll(bundle.getImportedPackages());
         packages.addAll(bundle.getExportedPackages());
+        packages.addAll(bundle.getUsedPackages());
+        List<Set<UsesConstraint>> usesConstraintsList = stripUsesConstraints(packages);
         packageRepository.save(packages);
-
+        replaceUses(usesConstraintsList, packages);
+        packageRepository.save(packages);
         // now save the bundle and it's relationships
         bundleRepository.save(bundle);
+    }
+
+    private List<Set<UsesConstraint>> stripUsesConstraints(List<Package> packages) {
+        List<Set<UsesConstraint>> usesConstraintsList = new ArrayList<Set<UsesConstraint>>();
+        for (Package pakage : packages) {
+            usesConstraintsList.add(pakage.getUsesConstraints());
+            pakage.setUsesConstraints(new HashSet<UsesConstraint>());
+        }
+        return usesConstraintsList;
+    }
+
+    private void replaceUses(List<Set<UsesConstraint>> usesConstraintsList, List<Package> packages) {
+        int i = 0;
+        for (Package pakage: packages) {
+            pakage.setUsesConstraints(usesConstraintsList.get(i));
+            i++;
+        }
     }
 
     protected String parseBundleSymbolicName(String bsn) { return bsn; }

--- a/src/main/java/org/neo4j/osgi/importer/entity/Bundle.java
+++ b/src/main/java/org/neo4j/osgi/importer/entity/Bundle.java
@@ -120,6 +120,23 @@ public class Bundle {
         return toReturn;
     }
 
+    public Collection<? extends Package> getUsedPackages() {
+        List<Package> toReturn = new ArrayList<Package>();
+        if (packageExports != null) {
+            for (PackageExport packageExport : packageExports) {
+                Package pkg = packageExport.getPackage();
+                if (pkg != null) {
+                    for (UsesConstraint usesConstraint : pkg.getUsesConstraints()) {
+                        if (usesConstraint != null && usesConstraint.getPackageUsed() != null) {
+                                   toReturn.add(usesConstraint.getPackageUsed());
+                        }
+                    }
+                }
+            }
+        }
+        return toReturn;
+    }
+
     @Override
     public String toString() {
         return "Bundle{" +

--- a/src/main/java/org/neo4j/osgi/importer/entity/UsesConstraint.java
+++ b/src/main/java/org/neo4j/osgi/importer/entity/UsesConstraint.java
@@ -21,7 +21,7 @@ public class UsesConstraint {
     private Package constrainedPackage;
 
     @RelatedTo(type = "USES", direction = Direction.OUTGOING)
-    private Package packagedUsed;
+    private Package packageUsed;
 
     public UsesConstraint() { }
 
@@ -31,11 +31,11 @@ public class UsesConstraint {
      * being exported).  The relationship between (exported package)->(used package)
      * is created when you add this instance to a {@link org.neo4j.osgi.importer.entity.Package}.
      *
-     * @param packagedUsed The package used.
+     * @param packageUsed The package used.
      * @since 0.0.1
      */
-    public UsesConstraint(Package packagedUsed) {
-        this.packagedUsed = packagedUsed;
+    public UsesConstraint(Package packageUsed) {
+        this.packageUsed = packageUsed;
     }
 
 
@@ -57,12 +57,12 @@ public class UsesConstraint {
         return this;
     }
 
-    public Package getPackagedUsed() {
-        return packagedUsed;
+    public Package getPackageUsed() {
+        return packageUsed;
     }
 
-    public UsesConstraint setPackagedUsed(Package packagedUsed) {
-        this.packagedUsed = packagedUsed;
+    public UsesConstraint setPackageUsed(Package packageUsed) {
+        this.packageUsed = packageUsed;
         return this;
     }
 }

--- a/src/main/scala/org/neo4j/osgi/Attribute.scala
+++ b/src/main/scala/org/neo4j/osgi/Attribute.scala
@@ -1,0 +1,8 @@
+package org.neo4j.osgi
+
+/**
+ * A Simple case class to define Attributes
+ * @author <a href="mailto:brdlmaier49@gmail.com">Bradley Maier</a>
+ * @since 0.0.1
+ */
+case class Attribute (key: String, value: String)

--- a/src/main/scala/org/neo4j/osgi/Directive.scala
+++ b/src/main/scala/org/neo4j/osgi/Directive.scala
@@ -1,0 +1,8 @@
+package org.neo4j.osgi
+
+/**
+ * A simple case class to define Directives
+ * @author <a href="mailto:brdlmaier49@gmail.com">Bradley Maier</a>
+ * @since 0.0.1
+ */
+case class Directive (key: String, value: String)

--- a/src/main/scala/org/neo4j/osgi/parser/ExportStatement.scala
+++ b/src/main/scala/org/neo4j/osgi/parser/ExportStatement.scala
@@ -1,6 +1,9 @@
 package org.neo4j.osgi.parser
 
-import org.neo4j.osgi.importer.entity.PackageExport
+import java.util
+
+import org.neo4j.osgi.importer.entity.{UsesConstraint, PackageExport, Package}
+import scala.collection.JavaConversions._
 
 /**
  * @author <a href="mailto:brdlmaier49@gmail.com">Bradley Maier</a>
@@ -8,18 +11,36 @@ import org.neo4j.osgi.importer.entity.PackageExport
  */
 object ExportStatement {
 
-  //TODO - Deal with uses statements. This will require some updates to the model
   def parse(exportStatement: String): List[PackageExport] = {
 
     val packagesDirectivesAndAttributes = PackageImportExport.parsePackageImportExportStatment(exportStatement)
-    val versions = packagesDirectivesAndAttributes._3.filter(_._1.equalsIgnoreCase("version"))
-    val version = if (versions.isEmpty) "0.0.0" else versions(0)._2
+    val versions = packagesDirectivesAndAttributes._3.filter(_.key.equalsIgnoreCase("version"))
+    val version = if (versions.isEmpty) "0.0.0" else versions(0).value
+    val usesDirectives = packagesDirectivesAndAttributes._2.filter(_.key.equalsIgnoreCase("uses"))
+    val usedPackages: util.Set[Package] = if (usesDirectives.isEmpty) {
+      new util.HashSet[Package]()
+    } else {
+      getUsesPackages(usesDirectives(0).value.split(','))
+    }
 
-    packagesDirectivesAndAttributes._1.map(
+    packagesDirectivesAndAttributes._1.map(pakage => {
+      val usesConstraintsForPakage = usedPackages.map(usedPackage =>
+        new UsesConstraint()
+          .setConstrainedPackage(pakage)
+          .setPackageUsed(usedPackage)
+      )
+
       new PackageExport()
-        .setPackage(_)
+        .setPackage(pakage.setUsesConstraints(usesConstraintsForPakage))
         .setVersion(version)
-    )
+    })
+  }
+
+  def getUsesPackages(packageNames: Array[String]): java.util.Set[Package] = {
+    packageNames
+      .map(new Package(_))
+      .toSet[Package]
+
   }
 
 }

--- a/src/main/scala/org/neo4j/osgi/parser/ImportStatement.scala
+++ b/src/main/scala/org/neo4j/osgi/parser/ImportStatement.scala
@@ -18,10 +18,10 @@ object ImportStatement {
   def parse(importStatement: String): List[PackageImport] = {
 
     val packagesDirectivesAndAttributes = PackageImportExport.parsePackageImportExportStatment(importStatement)
-    val resolutions = packagesDirectivesAndAttributes._2.filter(_._1.equalsIgnoreCase("resolution"))
-    val resolution = if (resolutions.isEmpty) "mandatory" else resolutions(0)._2
-    val versions = packagesDirectivesAndAttributes._3.filter(_._1.equalsIgnoreCase("version"))
-    val version = if (versions.isEmpty) "0.0.0" else versions(0)._2
+    val resolutions = packagesDirectivesAndAttributes._2.filter(_.key.equalsIgnoreCase("resolution"))
+    val resolution = if (resolutions.isEmpty) "mandatory" else resolutions(0).value
+    val versions = packagesDirectivesAndAttributes._3.filter(_.key.equalsIgnoreCase("version"))
+    val version = if (versions.isEmpty) "0.0.0" else versions(0).value
 
     buildPackageImports(packagesDirectivesAndAttributes._1, resolution, version)
   }

--- a/src/main/scala/org/neo4j/osgi/parser/PackageImportExport.scala
+++ b/src/main/scala/org/neo4j/osgi/parser/PackageImportExport.scala
@@ -1,5 +1,6 @@
 package org.neo4j.osgi.parser
 
+import org.neo4j.osgi.{Attribute, Directive}
 import org.neo4j.osgi.importer.entity.Package
 
 /**
@@ -14,7 +15,7 @@ private object PackageImportExport {
 
   /*TODO Decide whether defining what are essentially key values pairs in a directive and attribute class is
   worth the added type information */
-  def parsePackageImportExportStatment(statement: String): (List[Package], List[(String, String)], List[(String, String)]) = {
+  def parsePackageImportExportStatment(statement: String): (List[Package], List[Directive], List[Attribute]) = {
     val packageNamesAndParameters = statement.split(";")
 
     val packages = packageNamesAndParameters.filter(
@@ -27,8 +28,8 @@ private object PackageImportExport {
 
     return (
       packages.map(new Package(_)),
-      directives.map(directive => (directive.split(":=")(0), directive.split(":=")(1).filterNot(_ == '"'))),
-      attributes.map(attribute => (attribute.split("=")(0), attribute.split("=")(1).filterNot(_ == '"')))
+      directives.map(directive => Directive(directive.split(":=")(0), directive.split(":=")(1).filterNot(_ == '"'))),
+      attributes.map(attribute => Attribute(attribute.split("=")(0), attribute.split("=")(1).filterNot(_ == '"')))
       )
 
   }

--- a/src/test/groovy/org/neo4j/osgi/importer/entity/PackageExportSpec.groovy
+++ b/src/test/groovy/org/neo4j/osgi/importer/entity/PackageExportSpec.groovy
@@ -49,7 +49,7 @@ class PackageExportSpec extends Specification {
         Package barPkg = new Package("com.bar")
 
         // a uses constraint
-        UsesConstraint uc = new UsesConstraint().setPackagedUsed(barPkg)
+        UsesConstraint uc = new UsesConstraint().setPackageUsed(barPkg)
 
         // the constraint exists on foo --> bar
         fooPkg.addUsesConstraint(uc)
@@ -70,7 +70,7 @@ class PackageExportSpec extends Specification {
         Package barPkg = new Package("com.bar")
 
         // a uses constraint
-        UsesConstraint uc = new UsesConstraint().setPackagedUsed(barPkg)
+        UsesConstraint uc = new UsesConstraint().setPackageUsed(barPkg)
 
         // the constraint exists on foo --> bar
         fooPkg.addUsesConstraint(uc)

--- a/src/test/scala/org/neo4j/osgi/parser/ExportStatementSpec.scala
+++ b/src/test/scala/org/neo4j/osgi/parser/ExportStatementSpec.scala
@@ -4,6 +4,7 @@ package org.neo4j.osgi.parser
 import org.junit.runner.RunWith
 import org.scalatest.FunSpec
 import org.scalatest.junit.JUnitRunner
+import org.neo4j.osgi.importer.entity.{UsesConstraint, Package}
 
 /**
  * @author <a href="mailto:brdlmaier49@gmail.com">Bradley Maier</a>
@@ -42,18 +43,53 @@ class ExportStatementSpec extends FunSpec {
           "my.package.name;my.other.package.name;my.third.package.name;version=3.0.0;resolution:=bananas"
         )
         assert(exportPackages.length == 3)
-        val myPackage = exportPackages(0)
-        val myOtherPackage = exportPackages(1)
-        val myThirdPackage = exportPackages(2)
+        val myPackageExport = exportPackages(0)
+        val myOtherPackageExport = exportPackages(1)
+        val myThirdPackageExport = exportPackages(2)
 
-        assert(myPackage.getPackage.getName == "my.package.name")
-        assert(myPackage.getVersion == "3.0.0")
+        assert(myPackageExport.getPackage.getName == "my.package.name")
+        assert(myPackageExport.getVersion == "3.0.0")
 
-        assert(myOtherPackage.getPackage.getName == "my.other.package.name")
-        assert(myOtherPackage.getVersion == "3.0.0")
+        assert(myOtherPackageExport.getPackage.getName == "my.other.package.name")
+        assert(myOtherPackageExport.getVersion == "3.0.0")
 
-        assert(myThirdPackage.getPackage.getName == "my.third.package.name")
-        assert(myThirdPackage.getVersion == "3.0.0")
+        assert(myThirdPackageExport.getPackage.getName == "my.third.package.name")
+        assert(myThirdPackageExport.getVersion == "3.0.0")
+      }
+
+      it("Should add uses statements to packages") {
+        val exportPackages = ExportStatement.parse(
+          "my.package.name;my.other.package.name;my.third.package.name;uses:=\"uses.this,uses.that\";version=3.0.0;resolution:=bananas"
+        )
+        assert(exportPackages.length == 3)
+        val myPackageExport = exportPackages(0)
+        val myOtherPackageExport = exportPackages(1)
+        val myThirdPackageExport = exportPackages(2)
+
+        assert(myPackageExport.getPackage.getName == "my.package.name")
+        assert(myPackageExport.getVersion == "3.0.0")
+        assert(myPackageExport.getPackage.getUsesConstraints.size() == 2)
+        assert(myPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.this") == 1)
+        assert(myPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.package.name") == 2)
+        assert(myPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.that") == 1)
+        assert(myPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.package.name") == 2)
+
+        assert(myOtherPackageExport.getPackage.getName == "my.other.package.name")
+        assert(myOtherPackageExport.getVersion == "3.0.0")
+        assert(myOtherPackageExport.getPackage.getUsesConstraints.size() == 2)
+        assert(myOtherPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.this") == 1)
+        assert(myOtherPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.other.package.name") == 2)
+        assert(myOtherPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.that") == 1)
+        assert(myOtherPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.other.package.name") == 2)
+
+        assert(myThirdPackageExport.getPackage.getName == "my.third.package.name")
+        assert(myThirdPackageExport.getVersion == "3.0.0")
+        assert(myThirdPackageExport.getPackage.getUsesConstraints.size() == 2)
+        assert(myThirdPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.this") == 1)
+        assert(myThirdPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.third.package.name") == 2)
+        assert(myThirdPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getPackageUsed.getName == "uses.that") == 1)
+        assert(myThirdPackageExport.getPackage.getUsesConstraints.toArray.count(_.asInstanceOf[UsesConstraint].getConstrainedPackage.getName == "my.third.package.name") == 2)
+
       }
 
     }


### PR DESCRIPTION
Now parses uses constraints on package exports.

Due to the way @RelatedToVia is currently working this
required the slightly ugly workaround of pulling out all the packages
and saving them without uses constraints before adding back the
uses constraints and saving them again.
